### PR TITLE
Map page styling

### DIFF
--- a/src/components/BadgeMap/BadgeMap.tsx
+++ b/src/components/BadgeMap/BadgeMap.tsx
@@ -115,20 +115,30 @@ const BadgeMap = (): JSX.Element => {
         }}
       />
       Found Badge 4
-      <img
-        className={styles.mapLabel}
-        src={sentinelsLabel}
-        alt="Sentinels of Change Logo"
-      />
-      <div
-        id="map"
-        style={{ width: "100%", height: MAP_HEIGHT }}
-        className={styles.map}
-      />
+      <div className={styles.mapScreen}>
+        <img
+          className={styles.mapLabel}
+          src={sentinelsLabel}
+          alt="Sentinels of Change Logo"
+        />
+        <div
+          id="map"
+          style={{ width: "100%", height: MAP_HEIGHT }}
+          className={styles.map}
+        />
+      </div>
       <IconButton
-        onClick={() => {setCenterToClosestPin(map.current, userPin.current, badgePins, foundBadges)}}
+        onClick={() => {
+          setCenterToClosestPin(
+            map.current,
+            userPin.current,
+            badgePins,
+            foundBadges
+          );
+        }}
         text={"Find the next Badge!"}
         icon={Ellipse}
+        buttonStyle="w-fit px-14"
       />
     </div>
   );

--- a/src/components/BadgeMap/BadgeMap.tsx
+++ b/src/components/BadgeMap/BadgeMap.tsx
@@ -8,6 +8,7 @@ import {
   createMap,
   getClosestPinIndex,
   createBackgroundLayer,
+  setCenterToClosestPin,
 } from "./Utilities/utilities";
 import sentinelsLabel from "../../images/sentinelsLabel.png";
 import styles from "./styles";
@@ -124,7 +125,11 @@ const BadgeMap = (): JSX.Element => {
         style={{ width: "100%", height: MAP_HEIGHT }}
         className={styles.map}
       />
-      <IconButton text={"Find the next Badge!"} icon={Ellipse} />
+      <IconButton
+        onClick={() => {setCenterToClosestPin(map.current, userPin.current, badgePins, foundBadges)}}
+        text={"Find the next Badge!"}
+        icon={Ellipse}
+      />
     </div>
   );
 };

--- a/src/components/BadgeMap/Utilities/utilities.tsx
+++ b/src/components/BadgeMap/Utilities/utilities.tsx
@@ -195,6 +195,29 @@ const getClosestPinIndex = (
   return shortestDistanceIndex;
 };
 
+const setCenterToClosestPin = (
+  map: Map,
+  reference: VectorLayer<VectorSource<Point>>,
+  destinations: VectorLayer<VectorSource<Point>>[],
+  foundBadges: boolean[]
+): void => {
+  let closestPinIndex = getClosestPinIndex(
+    reference,
+    destinations,
+    foundBadges
+  );
+
+  map
+    .getView()
+    .setCenter(
+      destinations[closestPinIndex]
+        .getSource()
+        ?.getFeatures()[0]
+        .getGeometry()
+        ?.getCoordinates()
+    );
+};
+
 export {
   createBackgroundLayer,
   tryWatchLocation,
@@ -202,4 +225,5 @@ export {
   createUserPin,
   createMap,
   getClosestPinIndex,
+  setCenterToClosestPin,
 };

--- a/src/components/BadgeMap/styles.tsx
+++ b/src/components/BadgeMap/styles.tsx
@@ -1,7 +1,8 @@
 const styles = {
   mapContainer: "w-full",
-  mapLabel: "float-left pointer-events-none fixed z-10 ml-4 mt-4 h-12",
-  map: "z-20 rounded-3xl overflow-hidden",
+  mapScreen: "flex flex",
+  mapLabel: "-mr-40 pointer-events-none z-10 ml-4 mt-4 h-12",
+  map: "z-0 rounded-3xl overflow-hidden",
 };
 
 export default styles;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,7 +3,7 @@ import { MouseEventHandler } from "react";
 export abstract class ButtonProp {
   text?: string;
   buttonStyle?: string;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
+  onClick?: () => void;
 }
 
 const Button = (props: ButtonProp): JSX.Element => {

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -5,19 +5,26 @@ class IconButtonProp extends ButtonProp {
   icon?: string;
 }
 
-const IconButton = ({
-  text = "default",
-  icon = Missing,
-}: IconButtonProp): JSX.Element => {
+const IconButton = (
+  props: IconButtonProp = {
+    text: "default",
+    icon: Missing,
+  }
+): JSX.Element => {
   const styles = {
-    container: "flex flex-row w-full basis-full flex-wrap justify-center items-center",
+    container:
+      "flex flex-row w-full basis-full flex-wrap justify-center items-center",
     image: "z-[10] mr-[-30px]",
   };
 
   return (
     <div className={styles.container}>
-      <img className={styles.image} src={icon} alt={"logo"} />
-      <Button text={text} />
+      <img className={styles.image} src={props.icon} alt={"logo"} />
+      <Button
+        buttonStyle={props.buttonStyle}
+        onClick={props.onClick}
+        text={props.text}
+      />
     </div>
   );
 };


### PR DESCRIPTION
- Styled the map page to be like the Figma.
- Added custom colours (taken from the Figma) to the tailwind config file - primary, secondary, popout, darker, background, secondary-bg. Use these with Tailwind.
- The "Find the next Badge!" button centers the map on the next closest badge.
- The "Learn More" button leads to the Hakai website.
- Changed the location of the crab pins to be closer to the Figma locations.
- Added buttonStyle and onClick props to the Button components.